### PR TITLE
Timezones and Dates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ email: refinedbits@gmail.com
 authors: Andrew Bates, Bryce Handerson, and Chris Antes
 
 # Build settings
+timezone: America/Los_Angeles
 markdown: kramdown
 permalink: pretty
 url: http://refinedbitspodcast.com

--- a/_posts/2014-09-09-new-podcast.md
+++ b/_posts/2014-09-09-new-podcast.md
@@ -1,7 +1,6 @@
 ---
 title: new Podcast();
 description: Facebook Messenger, Naked Celebrities, Oculus Medicine, Robots Taking Human Jobs.
-date: 2014-09-09
 picture:
   src: /img/episodes/2014-09-09-new-podcast.jpg
   thumbnail-src: /img/episodes/thumbnails/2014-09-09-new-podcast.jpg

--- a/_posts/2014-10-14-kristin-valentine.md
+++ b/_posts/2014-10-14-kristin-valentine.md
@@ -1,7 +1,6 @@
 ---
 title: Kristin Valentine
 description: HTML5 Games, Shellshock, Windows 10, Euclideon, The Physical Web
-date: 2014-10-14
 picture:
   src: /img/episodes/2014-10-14-kristin-valentine.jpg
   thumbnail-src: /img/episodes/thumbnails/2014-10-14-kristin-valentine.jpg

--- a/_posts/2014-11-11-aaron-crandall.md
+++ b/_posts/2014-11-11-aaron-crandall.md
@@ -1,7 +1,6 @@
 ---
 title: Aaron S. Crandall, Ph.D
 description: Smart Homes, Gerontechnology, Language and Code Quality, Tabs vs. Spaces
-date: 2014-11-11
 picture:
   src: /img/episodes/2014-11-11-aaron-crandall.jpg
   thumbnail-src: /img/episodes/thumbnails/2014-11-11-aaron-crandall.jpg

--- a/_posts/2014-12-16-preparing-for-a-hackathon.md
+++ b/_posts/2014-12-16-preparing-for-a-hackathon.md
@@ -1,7 +1,6 @@
 ---
 title: Preparing for a Hackathon
 description: Essential tools and techniques for a successful hackathon
-date: 2014-12-16
 picture:
   src: /img/episodes/2014-12-16-preparing-for-a-hackathon.jpg
   thumbnail-src: /img/episodes/thumbnails/2014-12-16-preparing-for-a-hackathon.jpg

--- a/_posts/2015-02-14-at-the-hackathon.md
+++ b/_posts/2015-02-14-at-the-hackathon.md
@@ -1,7 +1,6 @@
 ---
 title: At the Hackathon
 description: We visit the third annual WSU EECS Hackathon and interview the teams working on some of our favorite projects
-date: 2015-02-14
 picture:
   src: /img/episodes/2015-02-14-at-the-hackathon.jpg
   thumbnail-src: /img/episodes/thumbnails/2015-02-14-at-the-hackathon.jpg


### PR DESCRIPTION
Noticed some date weirdness from the CI build:

```sh
$ diff public_html/feed.xml public_html_backup/feed.xml
17,19c17,19
<     <pubDate>Wed, 25 Feb 2015 07:29:12 +0000</pubDate>
<     <lastBuildDate>Wed, 25 Feb 2015 07:29:12 +0000</lastBuildDate>
<     <generator>Jekyll v2.5.3</generator>
---
>     <pubDate>Tue, 17 Feb 2015 23:14:02 -0800</pubDate>
>     <lastBuildDate>Tue, 17 Feb 2015 23:14:02 -0800</lastBuildDate>
>     <generator>Jekyll v2.3.0</generator>
58c58
<     <pubDate>Sat, 14 Feb 2015 00:00:00 +0000</pubDate>
---
>     <pubDate>Sat, 14 Feb 2015 00:00:00 -0800</pubDate>
74c74
<     <pubDate>Tue, 16 Dec 2014 00:00:00 +0000</pubDate>
---
>     <pubDate>Tue, 16 Dec 2014 00:00:00 -0800</pubDate>
90c90
<     <pubDate>Tue, 11 Nov 2014 00:00:00 +0000</pubDate>
---
>     <pubDate>Tue, 11 Nov 2014 00:00:00 -0800</pubDate>
106c106
<     <pubDate>Tue, 14 Oct 2014 00:00:00 +0000</pubDate>
---
>     <pubDate>Tue, 14 Oct 2014 00:00:00 -0700</pubDate>
122c122
<     <pubDate>Tue, 09 Sep 2014 00:00:00 +0000</pubDate>
---
>     <pubDate>Tue, 09 Sep 2014 00:00:00 -0700</pubDate>
```

This adds the [`timezone` option for the site](http://jekyllrb.com/docs/configuration/#global-configuration), so dates are interpreted correctly, even if the site is built in a different timezone (e.g., through CI).

This also removes the `date` property from the episode post front matter; [Jekyll automatically gets this from the filename](http://jekyllrb.com/docs/frontmatter/#predefined-variables-for-posts):

> A date here overrides the date from the name of the post. This can be used to ensure correct sorting of posts.

We don't have multiple posts within the same day, so this is not a concern for us.